### PR TITLE
Add prefetch.sh

### DIFF
--- a/prefetch.sh
+++ b/prefetch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+git clone --depth=1 https://go.googlesource.com/sys /home/user/go/src/golang.org/x/sys
+git clone --depth=1 https://go.googlesource.com/crypto /home/user/go/src/golang.org/x/crypto
+
+URLLIST="
+gopkg.in/bsm/ratelimit.v1
+gopkg.in/karalabe/cookiejar.v2
+gopkg.in/redis.v3
+github.com/denisbrodbeck/machineid
+github.com/fatih/color
+github.com/golang/snappy
+github.com/gorilla/mux
+github.com/mattn/go-colorable
+github.com/mattn/go-isatty
+github.com/mintme-com/cpuid
+github.com/rcrowley/go-metrics
+github.com/syndtr/goleveldb
+github.com/webchain-network/cryptonight
+github.com/webchain-network/webchaind
+github.com/yvasiyarov/go-metrics
+github.com/yvasiyarov/gorelic
+github.com/yvasiyarov/newrelic_platform_go
+"
+
+for URL in $URLLIST; do
+	git clone --depth=1 "https://${URL}" "/home/user/go/src/${URL}"
+done

--- a/prefetch.sh
+++ b/prefetch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-git clone --depth=1 https://go.googlesource.com/sys /home/user/go/src/golang.org/x/sys
-git clone --depth=1 https://go.googlesource.com/crypto /home/user/go/src/golang.org/x/crypto
+git clone --depth=1 https://go.googlesource.com/sys "$HOME/go/src/golang.org/x/sys"
+git clone --depth=1 https://go.googlesource.com/crypto "$HOME/go/src/golang.org/x/crypto"
 
 URLLIST="
 gopkg.in/bsm/ratelimit.v1
@@ -24,5 +24,5 @@ github.com/yvasiyarov/newrelic_platform_go
 "
 
 for URL in $URLLIST; do
-	git clone --depth=1 "https://${URL}" "/home/user/go/src/${URL}"
+	git clone --depth=1 "https://${URL}" "$HOME/go/src/${URL}"
 done

--- a/prefetch.sh
+++ b/prefetch.sh
@@ -24,5 +24,8 @@ github.com/yvasiyarov/newrelic_platform_go
 "
 
 for URL in $URLLIST; do
-	git clone --depth=1 "https://${URL}" "$HOME/go/src/${URL}"
+	while true; do # Retry until successful - some servers fail often
+		git clone --depth=1 "https://${URL}" "$HOME/go/src/${URL}" && break
+		echo "Retrying..."
+	done
 done


### PR DESCRIPTION
Closes: #47

I've figured it out. the problem is, even though Go is supposed to [create shallow clones when handling modules](https://github.com/golang/go/issues/13078#issuecomment-543863761), it does not, and I've confirmed it. Instead, it clones the whole repository, *recursively*, dragging another repository with 1.3Gb of tests with it. And we only need a few modules - if I understand correctly, to interface with core-geth.

The Go community agrees that this behavior should be changed, but are still figuring out the "proper" way to implement it. [Earlier attempts](https://go-review.googlesource.com/c/go/+/16360/) have ended up in failure and a consequent [revert](https://go-review.googlesource.com/c/go/+/16832/). So there is no way to configure Go to make a non-recursive shallow clone.

What we can do, however, is manually download shallow clones. This saves *a ton* of "build"/download time (shrinks download size from ~530M to ~16M !) and container space (reduces container size from ~3.4 Gb to ~1.9 Gb).

I'll add a PR to the documentation about this later.